### PR TITLE
Removing Auto Recovery from the templates (for now)

### DIFF
--- a/templates/mongodb-node.template
+++ b/templates/mongodb-node.template
@@ -601,7 +601,7 @@
             "Type": "AWS::CloudWatch::Alarm",
             "Condition": "InstanceRecoverySupported",
             "Properties": {
-                "AlarmDescription": "EC2 Autorecovery for Node Instance. Autorecover if we fail EC2 status checks for 5 minutes.",
+                "AlarmDescription": "EC2 Status Check Failed System for Node Instance.",
                 "Namespace": "AWS/EC2",
                 "MetricName": "StatusCheckFailed_System",
                 "Statistic": "Minimum",
@@ -609,24 +609,7 @@
                 "EvaluationPeriods": 5,
                 "ComparisonOperator": "GreaterThanThreshold",
                 "Threshold": 0.0,
-                "AlarmActions": [
-                    {
-                        "Fn::Join": [
-                            "",
-                            [
-                                "arn:",
-                                {
-                                    "Ref": "AWS::Partition"
-                                },
-                                ":automate:",
-                                {
-                                    "Ref": "AWS::Region"
-                                },
-                                ":ec2:recover"
-                            ]
-                        ]
-                    }
-                ],
+                "AlarmActions": [],
                 "Dimensions": [
                     {
                         "Name": "InstanceId",

--- a/templates/mongodb-node.template.yaml
+++ b/templates/mongodb-node.template.yaml
@@ -308,7 +308,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Condition: InstanceRecoverySupported
     Properties:
-      AlarmDescription: EC2 Autorecovery for Node Instance. Autorecover if we fail
+      AlarmDescription: EC2 Status Check Failed System for Node Instance.
         EC2 status checks for 5 minutes.
       Namespace: AWS/EC2
       MetricName: StatusCheckFailed_System
@@ -317,8 +317,6 @@ Resources:
       EvaluationPeriods: 5
       ComparisonOperator: GreaterThanThreshold
       Threshold: 0.0
-      AlarmActions:
-        - !Sub 'arn:${AWS::Partition}:automate:${AWS::Region}:ec2:recover'
       Dimensions:
         - Name: InstanceId
           Value: !Ref 'ReplicaNodeInstance'


### PR DESCRIPTION
**WHAT/WHY**

We don't want to auto-recover until we're certain we can test this in isolation. For now, let's remove it.

**HOW**

Removed them from 2 instances in the templates. This needs testing to see if the template still works.

(We could try this out in the FTI account)