### PR TITLE
(DRAFT) Enabling x509 Certificate Auth for the Replica Set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+packaged-template.template

--- a/scripts/init_replica.sh
+++ b/scripts/init_replica.sh
@@ -138,12 +138,12 @@ check_primary() {
 }
 
 setup_security_common() {
-    DDB_TABLE=$1
-    auth_key=$(./orchestrator.sh -f -n $DDB_TABLE)
-    echo $auth_key > /mongo_auth/mongodb.key
-    chmod 400 /mongo_auth/mongodb.key
-    chown -R mongod:mongod /mongo_auth
-    sed $'s/processManagement:/security: \\\n  authorization: disabled \\\n  keyFile: \/mongo_auth\/mongodb.key \\\n\\\n&/g' /etc/mongod.conf >> /tmp/mongod_sec.txt
+    # DDB_TABLE=$1
+    # auth_key=$(./orchestrator.sh -f -n $DDB_TABLE)
+    # echo $auth_key > /mongo_auth/mongodb.key
+    # chmod 400 /mongo_auth/mongodb.key
+    # chown -R mongod:mongod /mongo_auth
+    sed $'s/processManagement:/security: \\\n  authorization: enabled \\\n  clusterAuthMode: x509 \\\n\\\n&/g' /etc/mongod.conf >> /tmp/mongod_sec.txt
     mv /tmp/mongod_sec.txt /etc/mongod.conf
 }
 
@@ -174,6 +174,13 @@ echo "  port:" >> mongod.conf
 if [ "$version" == "3.6" ] || [ "$version" == "4.0" ] || [ "$version" == "4.2" ] || [ "$version" == "5.0" ] || [ "$version" == "6.0" ]; then
     echo "  bindIpAll: true" >> mongod.conf
 fi
+echo "  tls:" >> mongod.conf
+echo "    mode: requireTLS" >> mongod.conf
+echo "    CAFile: /etc/mongodb/ssl/ca.crt" >> mongod.conf
+echo "    certificateKeyFile: /etc/mongodb/ssl/node.pem" >> mongod.conf
+echo "    clusterFile: /etc/mongodb/ssl/node.pem" >> mongod.conf
+echo "    clusterPassword: $certPassphrase" >> mongod.conf
+echo "    certificateKeyFilePassword: $certPassphrase" >> mongod.conf
 echo "" >> mongod.conf
 echo "systemLog:" >> mongod.conf
 echo "  destination: file" >> mongod.conf

--- a/templates/mongodb-master.template
+++ b/templates/mongodb-master.template
@@ -91,7 +91,7 @@
                 },
                 "Certificate": {
                     "default": "Certificate File"
-                }
+                },
                 "AvailabilityZones": {
                     "default": "Availability Zones"
                 },
@@ -415,7 +415,7 @@
             "Default": "",
             "MinLength": 1,
             "MaxLength": 1,
-            "MaxLength: 1024,
+            "MaxLength": 1024,
             "ConstraintDescription": "Must be a valid key file."
         },
         "Certificate": {
@@ -423,7 +423,7 @@
             "Default": "",
             "MinLength": 1,
             "MaxLength": 1,
-            "MaxLength: 1024,
+            "MaxLength": 1024,
             "ConstraintDescription": "Must be a valid certificate file."
         },
         "ReplicaShardIndex": {
@@ -445,7 +445,7 @@
                 },
                 "true"
             ]
-        }
+        },
         "CreateThreeReplicaSet": {
             "Fn::Equals": [
                 {

--- a/templates/mongodb-master.template
+++ b/templates/mongodb-master.template
@@ -62,9 +62,36 @@
                         "QSS3KeyPrefix",
                         "QSS3BucketRegion"
                     ]
+                },
+                {
+                    "Label": {
+                        "default": "TLS Settings"
+                    },
+                    "Parameters": [
+                        "TLS"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "Key and Certificate"
+                    },
+                    "Parameters": [
+                        "Key",
+                        "Certificate"
+                    ],
+                    "Condition": "EnableTLS"
                 }
             ],
             "ParameterLabels": {
+                "TLS": {
+                    "default": "Enable TLS"
+                },
+                "Key": {
+                    "default": "Key File"
+                },
+                "Certificate": {
+                    "default": "Certificate File"
+                }
                 "AvailabilityZones": {
                     "default": "Availability Zones"
                 },
@@ -379,6 +406,26 @@
                 "3"
             ]
         },
+        "TLS": {
+            "Type": "Boolean",
+            "Default": "false"
+        },
+        "Key": {
+            "Type": "String",
+            "Default": "",
+            "MinLength": 1,
+            "MaxLength": 1,
+            "MaxLength: 1024,
+            "ConstraintDescription": "Must be a valid key file."
+        },
+        "Certificate": {
+            "Type": "String",
+            "Default": "",
+            "MinLength": 1,
+            "MaxLength": 1,
+            "MaxLength: 1024,
+            "ConstraintDescription": "Must be a valid certificate file."
+        },
         "ReplicaShardIndex": {
             "Description": "Shard Index of this replica set",
             "Type": "String",
@@ -391,6 +438,14 @@
         }
     },
     "Conditions": {
+        "EnableTLS": {
+            "Fn::Equals": [
+                {
+                    "Ref": "TLS"
+                },
+                "true"
+            ]
+        }
         "CreateThreeReplicaSet": {
             "Fn::Equals": [
                 {

--- a/templates/mongodb.template
+++ b/templates/mongodb.template
@@ -302,14 +302,14 @@
         },
         "Key": {
             "Type": "String",
-            "Default": "X",
+            "Default": "",
             "MinLength": 1,
             "MaxLength": 1024,
             "ConstraintDescription": "Must be a valid key file."
         },
         "Certificate": {
             "Type": "String",
-            "Default": "X",
+            "Default": "",
             "MinLength": 1,
             "MaxLength": 1024,
             "ConstraintDescription": "Must be a valid certificate file."

--- a/templates/mongodb.template
+++ b/templates/mongodb.template
@@ -302,14 +302,14 @@
         },
         "Key": {
             "Type": "String",
-            "Default": "",
+            "Default": "-----BEGIN PRIVATE KEY----- -----END PRIVATE KEY-----",
             "MinLength": 1,
             "MaxLength": 1024,
             "ConstraintDescription": "Must be a valid key file."
         },
         "Certificate": {
             "Type": "String",
-            "Default": "",
+            "Default": "-----BEGIN CERTIFICATE----- -----END CERTIFICATE-----",
             "MinLength": 1,
             "MaxLength": 1024,
             "ConstraintDescription": "Must be a valid certificate file."

--- a/templates/mongodb.template
+++ b/templates/mongodb.template
@@ -302,17 +302,15 @@
         },
         "Key": {
             "Type": "String",
-            "Default": "",
+            "Default": "X",
             "MinLength": 1,
-            "MaxLength": 1,
             "MaxLength": 1024,
             "ConstraintDescription": "Must be a valid key file."
         },
         "Certificate": {
             "Type": "String",
-            "Default": "",
+            "Default": "X",
             "MinLength": 1,
-            "MaxLength": 1,
             "MaxLength": 1024,
             "ConstraintDescription": "Must be a valid certificate file."
         }

--- a/templates/mongodb.template
+++ b/templates/mongodb.template
@@ -302,15 +302,15 @@
         },
         "Key": {
             "Type": "String",
-            "Default": "-----BEGIN PRIVATE KEY----- -----END PRIVATE KEY-----",
-            "MinLength": 1,
+            "Default": "",
+            "MinLength": 0,
             "MaxLength": 1024,
             "ConstraintDescription": "Must be a valid key file."
         },
         "Certificate": {
             "Type": "String",
-            "Default": "-----BEGIN CERTIFICATE----- -----END CERTIFICATE-----",
-            "MinLength": 1,
+            "Default": "",
+            "MinLength": 0,
             "MaxLength": 1024,
             "ConstraintDescription": "Must be a valid certificate file."
         }

--- a/templates/mongodb.template
+++ b/templates/mongodb.template
@@ -293,7 +293,11 @@
             "Description": "Subnet-ID the existing subnet in your VPC where you want to deploy Secondary node(s)."
         },
         "TLS": {
-            "Type": "Boolean",
+            "Type": "String",
+            "AllowedValues": [
+                    "false",
+                    "true"
+                ],
             "Default": "false"
         },
         "Key": {

--- a/templates/mongodb.template
+++ b/templates/mongodb.template
@@ -6,6 +6,24 @@
             "ParameterGroups": [
                 {
                     "Label": {
+                        "default": "TLS Settings"
+                    },
+                    "Parameters": [
+                        "TLS"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "Key and Certificate"
+                    },
+                    "Parameters": [
+                        "Key",
+                        "Certificate"
+                    ],
+                    "Condition": "EnableTLS"
+                },
+                {
+                    "Label": {
                         "default": "Network Configuration"
                     },
                     "Parameters": [
@@ -97,6 +115,15 @@
                 },
                 "VolumeType": {
                     "default": "Volume Type"
+                },
+                "TLS": {
+                    "default": "Enable TLS"
+                },
+                "Key": {
+                    "default": "Key File"
+                },
+                "Certificate": {
+                    "default": "Certificate File"
                 }
             }
         }
@@ -264,9 +291,37 @@
         "Secondary1NodeSubnet": {
             "Type": "AWS::EC2::Subnet::Id",
             "Description": "Subnet-ID the existing subnet in your VPC where you want to deploy Secondary node(s)."
+        },
+        "TLS": {
+            "Type": "Boolean",
+            "Default": "false"
+        },
+        "Key": {
+            "Type": "String",
+            "Default": "",
+            "MinLength": 1,
+            "MaxLength": 1,
+            "MaxLength": 1024,
+            "ConstraintDescription": "Must be a valid key file."
+        },
+        "Certificate": {
+            "Type": "String",
+            "Default": "",
+            "MinLength": 1,
+            "MaxLength": 1,
+            "MaxLength": 1024,
+            "ConstraintDescription": "Must be a valid certificate file."
         }
     },
     "Conditions": {
+        "EnableTLS": {
+            "Fn::Equals": [
+                {
+                    "Ref": "TLS"
+                },
+                "true"
+            ]
+        },
         "CreateThreeReplicaSet": {
             "Fn::Equals": [
                 {


### PR DESCRIPTION
**WHAT/WHY**

We need to add x509 authorization for the replica set using certificates for each node to be able to do internal authentication and so that clients (web services) can connect to the DB with a hierarchy of permissions pre-set for each certificate 

**HOW**

We need to:

- Change the _mongod.conf_ file to show these changes
- We also need to add some changes in the following file:
`aws-mongodb-replicaset/templates/mongodb-node.template` to get the certificates from Secrets Manager
- We also need to allow/create certain permissions in the AWS side of things so that CloudFormation can talk to Secrets Manager for doing this. 